### PR TITLE
Settings Modal: Added Custom Links + Minor Fixes

### DIFF
--- a/src/components/Modal/SettingsModal.tsx
+++ b/src/components/Modal/SettingsModal.tsx
@@ -18,6 +18,8 @@ export enum ViewIds {
   currency
 }
 
+type CustomButtonType = 'core' | 'tools'
+
 export const SettingsModal: React.FC<{
   isOpen: boolean
   closeModal: () => void
@@ -27,8 +29,9 @@ export const SettingsModal: React.FC<{
   langs: { [locale: string]: { name: string; nativeName: string } }
   currentLang: string
   changeLang: (locale: string) => void
+  customButtonType?: CustomButtonType
 }> = (props) => {
-  const { isOpen, networkView, walletChainId, langs, currentLang, changeLang, closeModal, t } =
+  const { isOpen, networkView, walletChainId, langs, currentLang, changeLang, closeModal, t, customButtonType } =
     props
   const [selectedViewId, setSelectedViewId] = useState<string | number>(ViewIds.main)
 
@@ -78,6 +81,7 @@ export const SettingsModal: React.FC<{
       langs={langs}
       currentLang={currentLang}
       changeLang={changeLang}
+      customButtonType={customButtonType}
     />
   )
 }
@@ -93,9 +97,10 @@ const MainView: React.FC<
     t: i18nTranslate
     langs: { [locale: string]: { name: string; nativeName: string } }
     currentLang: string
+    customButtonType?: CustomButtonType
   } & ViewProps
 > = (props) => {
-  const { t, chainId, setSelectedViewId, langs, currentLang } = props
+  const { t, chainId, setSelectedViewId, langs, currentLang, customButtonType } = props
   return (
     <div className='flex flex-col justify-between xs:justify-start h-full'>
       <div className='grid grid-cols-2 gap-3'>
@@ -108,7 +113,7 @@ const MainView: React.FC<
           langs={langs}
           currentLang={currentLang}
         />
-        <ToolsButton t={t} />
+        <CustomButton type={customButtonType} t={t} />
         <DeveloperButton t={t} />
       </div>
 
@@ -188,22 +193,35 @@ const DeveloperButton = (props: { t: i18nTranslate }) => {
   )
 }
 
-const ToolsButton = (props: { t: i18nTranslate }) => {
-  const { t } = props
+const CustomButton = (props: { type?: CustomButtonType, t: i18nTranslate }) => {
+  const { type: buttonType, t } = props
+
+  // Default Custom Button (Tools):
+  let link = 'https://tools.pooltogether.com'
+  let topText = t?.('tools') || 'Tools'
+  let bottomText = t?.('pooltogetherToolkit') || 'PoolTogether Toolkit'
+
+  // Core App Button:
+  if (buttonType === 'core') {
+    link = 'https://app.pooltogether.com'
+    topText = t?.('coreApp') || 'Core App'
+    bottomText = t?.('pooltogetherCoreApp') || 'PoolTogether App'
+  }
+
   return (
     <a
-      href={'https://tools.pooltogether.com'}
+      href={link}
       className={classNames(
         'flex flex-col items-center p-3 rounded-lg bg-white bg-opacity-100 dark:bg-white dark:bg-opacity-10 w-full transition hover:bg-opacity-50 dark:hover:bg-opacity-5'
       )}
       target='_blank'
     >
       <div className='text-xs flex space-x-1 items-center'>
-        <span>{t?.('tools') || 'Tools'}</span>
+        <span>{topText}</span>
         <FeatherIcon icon='arrow-up-right' className='w-3 h-4' />
       </div>
       <div className='text-xxxs opacity-50'>
-        {t?.('pooltogetherToolkit') || 'PoolTogether Toolkit'}
+        {bottomText}
       </div>
     </a>
   )

--- a/src/components/Modal/SettingsModal.tsx
+++ b/src/components/Modal/SettingsModal.tsx
@@ -18,7 +18,11 @@ export enum ViewIds {
   currency
 }
 
-type CustomButtonType = 'core' | 'tools'
+interface CustomButton {
+  link: string
+  title: string
+  description: string
+}
 
 export const SettingsModal: React.FC<{
   isOpen: boolean
@@ -29,9 +33,9 @@ export const SettingsModal: React.FC<{
   langs: { [locale: string]: { name: string; nativeName: string } }
   currentLang: string
   changeLang: (locale: string) => void
-  customButtonType?: CustomButtonType
+  customButton?: CustomButton
 }> = (props) => {
-  const { isOpen, networkView, walletChainId, langs, currentLang, changeLang, closeModal, t, customButtonType } =
+  const { isOpen, networkView, walletChainId, langs, currentLang, changeLang, closeModal, t, customButton } =
     props
   const [selectedViewId, setSelectedViewId] = useState<string | number>(ViewIds.main)
 
@@ -81,7 +85,7 @@ export const SettingsModal: React.FC<{
       langs={langs}
       currentLang={currentLang}
       changeLang={changeLang}
-      customButtonType={customButtonType}
+      customButton={customButton}
     />
   )
 }
@@ -97,10 +101,10 @@ const MainView: React.FC<
     t: i18nTranslate
     langs: { [locale: string]: { name: string; nativeName: string } }
     currentLang: string
-    customButtonType?: CustomButtonType
+    customButton?: CustomButton
   } & ViewProps
 > = (props) => {
-  const { t, chainId, setSelectedViewId, langs, currentLang, customButtonType } = props
+  const { t, chainId, setSelectedViewId, langs, currentLang, customButton } = props
   return (
     <div className='flex flex-col justify-between xs:justify-start h-full'>
       <div className='grid grid-cols-2 gap-3'>
@@ -113,7 +117,7 @@ const MainView: React.FC<
           langs={langs}
           currentLang={currentLang}
         />
-        <CustomButton type={customButtonType} t={t} />
+        <CustomButton data={customButton} t={t} />
         <DeveloperButton t={t} />
       </div>
 
@@ -193,35 +197,22 @@ const DeveloperButton = (props: { t: i18nTranslate }) => {
   )
 }
 
-const CustomButton = (props: { type?: CustomButtonType, t: i18nTranslate }) => {
-  const { type: buttonType, t } = props
-
-  // Default Custom Button (Tools):
-  let link = 'https://tools.pooltogether.com'
-  let topText = t?.('tools') || 'Tools'
-  let bottomText = t?.('pooltogetherToolkit') || 'PoolTogether Toolkit'
-
-  // Core App Button:
-  if (buttonType === 'core') {
-    link = 'https://app.pooltogether.com'
-    topText = t?.('coreApp') || 'Core App'
-    bottomText = t?.('pooltogetherCoreApp') || 'PoolTogether App'
-  }
-
+const CustomButton = (props: { data?: CustomButton, t: i18nTranslate }) => {
+  const { data, t } = props
   return (
     <a
-      href={link}
+      href={data?.link || 'https://tools.pooltogether.com'}
       className={classNames(
         'flex flex-col items-center p-3 rounded-lg bg-white bg-opacity-100 dark:bg-white dark:bg-opacity-10 w-full transition hover:bg-opacity-50 dark:hover:bg-opacity-5'
       )}
       target='_blank'
     >
       <div className='text-xs flex space-x-1 items-center'>
-        <span>{topText}</span>
+        <span>{data?.title || (t?.('tools') || 'Tools')}</span>
         <FeatherIcon icon='arrow-up-right' className='w-3 h-4' />
       </div>
       <div className='text-xxxs opacity-50'>
-        {bottomText}
+        {data?.description || (t?.('pooltogetherToolkit') || 'PoolTogether Toolkit')}
       </div>
     </a>
   )

--- a/src/components/Modal/SettingsModal.tsx
+++ b/src/components/Modal/SettingsModal.tsx
@@ -187,7 +187,7 @@ const DeveloperButton = (props: { t: i18nTranslate }) => {
           ? isTestnets
             ? t?.('enableMainnets') || 'Enable mainnets'
             : t?.('enableTestnets') || 'Enable testnets'
-          : `(${5 - count})`
+          : `(${t?.('clickMoreTimes', { n: (5 - count).toString() }) || 5 - count})`
       }
     />
   )

--- a/src/components/Modal/SettingsModal.tsx
+++ b/src/components/Modal/SettingsModal.tsx
@@ -279,7 +279,7 @@ const Button: React.FC<{
       onClick={onClick}
       disabled={disabled}
       className={classNames(
-        'flex flex-col items-center p-3 rounded-lg bg-white bg-opacity-100 dark:bg-white dark:bg-opacity-10 w-full transition mt-auto',
+        'flex flex-col items-center justify-center p-3 rounded-lg bg-white bg-opacity-100 dark:bg-white dark:bg-opacity-10 w-full transition mt-auto min-h-full',
         {
           'cursor-not-allowed opacity-50': disabled,
           'hover:bg-opacity-50 dark:hover:bg-opacity-5': !disabled


### PR DESCRIPTION
I've added a `CustomButton`, where we can indicate what app the modal should link to.

By default, this is the tools app. If you pass `customButtonType={'core'}` for example, the modal will link to the core app.

I've also fixed the height scaling of the network button, that was previously not filling up its grid row when no wallet was connected.

The developer mode button also is a bit more explicit with its activation requirements; it will now say "click N more times" instead of just displaying "N". The key on locize for this is set as `clickMoreTimes`.