### PR TITLE
Fixed Modal Header BG

### DIFF
--- a/src/components/BottomSheet/BottomSheet.tsx
+++ b/src/components/BottomSheet/BottomSheet.tsx
@@ -146,7 +146,7 @@ const BottomSheetHeader = (props: {
       <CloseModalButton
         closeModal={closeModal}
         className={classNames('absolute top-3 right-2', {
-          'backdrop-filter backdrop-blur-xl rounded-full': !header
+          'rounded-full': !header
         })}
       />
       <span className={'text-inverse font-semibold mx-auto leading-none'}>{header}</span>

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -113,6 +113,7 @@ export const Modal = (props: ModalProps) => {
           >
             <ModalHeader
               header={header}
+              className={bgClassName}
               closeModal={closeModal}
               onPreviousClick={onPreviousClick}
               onNextClick={onNextClick}
@@ -140,13 +141,14 @@ Modal.defaultProps = {
 
 const ModalHeader = (props: {
   header: React.ReactNode
+  className?: string
   closeModal: () => void
   onPreviousClick: () => void
   onNextClick: () => void
 }) => {
-  const { header, closeModal, onPreviousClick, onNextClick } = props
+  const { header, className, closeModal, onPreviousClick, onNextClick } = props
   return (
-    <div className={classNames('z-1 sticky top-0')}>
+    <div className={classNames('z-1 sticky top-0', className)}>
       <div className='absolute left-4 flex space-x-2 items-center top-2'>
         {onPreviousClick && <PreviousButton onClick={onPreviousClick} />}
         {onNextClick && <NextButton onClick={onNextClick} />}


### PR DESCRIPTION
This PR just gives the modal's header background the same color as the modal itself, as before it was transparent and content could overlap with the header.

Also removed a remnant of the blur effect that was removed from most components but apparently not the `CloseModalButton`.